### PR TITLE
Fixing typos in R6 chapter (#1323)

### DIFF
--- a/R6.Rmd
+++ b/R6.Rmd
@@ -29,9 +29,9 @@ R6 is very similar to a base OOP system called __reference classes__, or RC for 
   active fields. Together, these allow you to hide data from the user, or
   expose private data for reading but not writing.
   
-* Section \@ref(r6-semantics) explores the consequnces of R6's reference 
+* Section \@ref(r6-semantics) explores the consequences of R6's reference 
   semantics. You'll learn about the use of finalizers to automatically
-  clean up any operations performed in the intializer, and a common gotcha
+  clean up any operations performed in the initializer, and a common gotcha
   if you use an R6 object as a field in another R6 object.
 
 * Section \@ref(why-r6) describes why I cover R6, rather than the base RC
@@ -187,7 +187,7 @@ hadley
 hadley$print
 ```
 
-From the perspective of R6, there is no relationship between `hadley` and `hadley2`; they just coincidentally share the same class name. This doesn't cause problems when using already developed R6 problems but can make interactive experimentation confusing. If you're changing the code and can't figure out why the results of method calls aren't any different, make sure you've re-constructed R6 objects with the new class.
+From the perspective of R6, there is no relationship between `hadley` and `hadley2`; they just coincidentally share the same class name. This doesn't cause problems when using already developed R6 objects but can make interactive experimentation confusing. If you're changing the code and can't figure out why the results of method calls aren't any different, make sure you've re-constructed R6 objects with the new class.
 
 ### Adding methods after creation
 
@@ -468,11 +468,11 @@ y <- List$new(b = 2)
 z <- f(x, y)
 ```
 
-The final line is much harder to reason about:  if `f()` calls methods of `x` or `y`, it might modify them as well as `z`. This is the biggest potential downside of R6 and you should take care to avoid it by writing functions that either return a value, or modify their R6 inputs, but not both. That said, doing both can lead to substantially simpler code in some cases, and we'll discuss further in Section \@ref(threading-state).
+The final line is much harder to reason about:  if `f()` calls methods of `x` or `y`, it might modify them as well as `z`. This is the biggest potential downside of R6 and you should take care to avoid it by writing functions that either return a value, or modify their R6 inputs, but not both. That said, doing both can lead to substantially simpler code in some cases, and we'll discuss this further in Section \@ref(threading-state).
 
 ### Finalizer
 
-One useful property of reference semantics is that it makes sense to think about when an R6 object is __finalized__, i.e. when it's deleted. This doesn't make sense for most objects because copy-on-modify semantics mean that there may be many transient versions of an object, as alluded to in Section \@ref(gc). For example, the following creates two two factor objects: the second is created when the levels are modified, leaving the first to be destroyed by the garbage collector.
+One useful property of reference semantics is that it makes sense to think about when an R6 object is __finalized__, i.e. when it's deleted. This doesn't make sense for most objects because copy-on-modify semantics mean that there may be many transient versions of an object, as alluded to in Section \@ref(gc). For example, the following creates two factor objects: the second is created when the levels are modified, leaving the first to be destroyed by the garbage collector.
 
 ```{r}
 x <- factor(c("a", "b", "c"))
@@ -564,8 +564,8 @@ R6 is very similar to a built-in OO system called __reference classes__, or RC f
   
 * R6 has comprehensive online documentation at <https://r6.r-lib.org>.
 
-* R6 has a simpler mechnaism for cross-package subclassing, which just 
-  works without you having to think about. For RC, read the details in the 
+* R6 has a simpler mechanism for cross-package subclassing, which just 
+  works without you having to think about it. For RC, read the details in the 
   "External Methods; Inter-Package Superclasses" section of `?setRefClass`.
 
 * RC mingles variables and fields in the same stack of environments so that you


### PR DESCRIPTION
* fix 2 typos

* replace problems by classes

* Revert "replace problems by classes"

This reverts commit d471baa30ed96ac29d3eea65294c3fc046f92774.

* replace problems by objects

* add missing word

* delete superfluous two

* fix typo

* add missing word